### PR TITLE
docs: remove dead mail.mistystep.io endpoint references

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,9 @@ Store keys in profiles:
 mkdir -p ~/.config/mercury
 cat > ~/.config/mercury/config.toml << 'EOF'
 [profiles.phaedrus]
-api_url = "https://mail.mistystep.io"
 # API key stored in 1Password: op://Personal/Mercury phaedrus/credential
 
 [profiles.kaylee]
-api_url = "https://mail.mistystep.io"
 # API key stored in 1Password: op://Personal/Mercury kaylee/credential
 EOF
 


### PR DESCRIPTION
Removal-only README correction: `mail.mistystep.io` has no DNS answer and was never replaced. Two example CLI profile config blocks referenced the dead hostname as `api_url`; removed those lines rather than inventing a replacement target.

Part of Powder card estate-022 (approved one-repository-at-a-time archived-repo unarchive/edit/readback/rearchive cycle, run-D7NHQFRA-bfm). No replacement endpoint invented per scope. Local gate verified before push: `npm run lint && npm run typecheck && npm run test` all pass (74/74 tests).